### PR TITLE
fixed error with setting DateTime property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - When creating and initializing `OpenXmlUnknownElement` variables, use the
   `CreateOpenXmlUnknownElement` static method instead of the traditional constructor.
 - When the `BuildCodeStatements` method of `OpenXmlElementExtensions` extensions class
-  encounterd a DateTime properity it was throwing a `System.ArgumentException` Invalid
+  encounterd a DateTime property it was throwing a `System.ArgumentException` Invalid
   Primitive Type System.DateTime. fixed by @vtgrady2k
   
 ## [0.4.2-beta] - 2021-11-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - When creating and initializing `OpenXmlUnknownElement` variables, use the
   `CreateOpenXmlUnknownElement` static method instead of the traditional constructor.
-
+- When the `BuildCodeStatements` method of `OpenXmlElementExtensions` extensions class
+  encounterd a DateTime properity it was throwing a `System.ArgumentException` Invalid
+  Primitive Type System.DateTime. fixed by @vtgrady2k
+  
 ## [0.4.2-beta] - 2021-11-22
 
 ### Changed

--- a/src/Serialize.OpenXml.CodeGen/OpenXmlElementExtensions.cs
+++ b/src/Serialize.OpenXml.CodeGen/OpenXmlElementExtensions.cs
@@ -538,10 +538,28 @@ namespace Serialize.OpenXml.CodeGen
                 {
                     propVal = val.GetType().GetProperty("Value").GetValue(val);
 
+                    CodeExpression codeExpression;
+
+                    if (propVal is DateTime)
+                    {
+                        var dt = Convert.ToDateTime(propVal);
+                        var kind = new CodeFieldReferenceExpression
+                            (
+                                new CodeTypeReferenceExpression("System.DateTimeKind"),
+                                dt.Kind.ToString()
+                            );
+
+                        codeExpression = new CodeObjectCreateExpression("System.DateTime", new CodePrimitiveExpression(dt.Ticks), kind);
+                    }
+                    else
+                    {
+                        codeExpression = new CodePrimitiveExpression(propVal);
+                    }
+
                     statement = new CodeAssignStatement(
                         new CodePropertyReferenceExpression(
                             new CodeVariableReferenceExpression(elementName), p.Name),
-                            new CodePrimitiveExpression(propVal));
+                            codeExpression);
                 }
                 result.Add(statement);
             }

--- a/src/Serialize.OpenXml.CodeGen/OpenXmlElementExtensions.cs
+++ b/src/Serialize.OpenXml.CodeGen/OpenXmlElementExtensions.cs
@@ -540,6 +540,13 @@ namespace Serialize.OpenXml.CodeGen
 
                     CodeExpression codeExpression;
 
+                    // If the current property value type is a DateTime
+                    // a CodeObjectCreateExpression must be used instead.
+                    // Per MS documentation:
+                    // Primitive data types that can be represented using CodePrimitiveExpression include
+                    // null; string; 16-, 32-, and 64-bit signed integers;
+                    // and single-precision and double-precision floating-point numbers.
+
                     if (propVal is DateTime)
                     {
                         var dt = Convert.ToDateTime(propVal);


### PR DESCRIPTION
fixed the following error: System.ArgumentException Invalid Primitive Type System.DateTime. Consider using CodeObjectCreateExpression